### PR TITLE
(hel-231) Le cache des pages 404 ne dure qu'une seconde

### DIFF
--- a/src/pages/entite-juridique/[numéroFiness].tsx
+++ b/src/pages/entite-juridique/[numéroFiness].tsx
@@ -12,6 +12,9 @@ export default function Router(
   { entitéJuridique: EntitéJuridique, établissementsTerritoriauxRattachés: ÉtablissementTerritorialRattaché[] }
 ) {
   const { wording } = useDependencies()
+
+  if (!établissementsTerritoriauxRattachés || !entitéJuridique) return null
+
   const entitéJuridiqueViewModel = new EntitéJuridiqueViewModel(entitéJuridique, wording)
   const établissementsTerritoriauxRattachésViewModels =
     établissementsTerritoriauxRattachés.map((établissementTerritorial) => new ÉtablissementTerritorialRattachéViewModel(établissementTerritorial, wording))
@@ -34,7 +37,7 @@ export async function getStaticProps({ params }: { params: { numéroFiness: stri
     const entitéJuridiqueEndpoint = await récupèreLEntitéJuridiqueEndpoint(dependencies, params.numéroFiness)
 
     if (entitéJuridiqueEndpoint === undefined) {
-      return { notFound: true }
+      return { notFound: true, revalidate: 1 }
     }
 
     return {
@@ -46,6 +49,6 @@ export async function getStaticProps({ params }: { params: { numéroFiness: stri
     }
   } catch (error) {
     dependencies.logger.error(error)
-    return { notFound: true }
+    return { notFound: true, revalidate: 1 }
   }
 }

--- a/src/pages/etablissement-territorial-medico-social/[numéroFiness].tsx
+++ b/src/pages/etablissement-territorial-medico-social/[numéroFiness].tsx
@@ -8,6 +8,9 @@ import { ÉtablissementTerritorialMédicoSocialViewModel } from '../../frontend/
 export default function Router({ établissementTerritorial }:
   { établissementTerritorial: ÉtablissementTerritorialMédicoSocial }) {
   const { paths, wording } = useDependencies()
+
+  if (!établissementTerritorial) return null
+
   const établissementTerritorialViewModel = new ÉtablissementTerritorialMédicoSocialViewModel(établissementTerritorial, wording, paths)
   return <PageÉtablissementTerritorialMédicoSocial établissementTerritorialViewModel={établissementTerritorialViewModel} />
 }
@@ -27,6 +30,6 @@ export async function getStaticProps({ params }: { params: { numéroFiness: stri
     return { props: { établissementTerritorial }, revalidate: Number(environmentVariables.TIME_OF_CACHE_PAGE) }
   } catch (error) {
     dependencies.logger.error(error)
-    return { notFound: true }
+    return { notFound: true, revalidate: 1 }
   }
 }

--- a/src/pages/etablissement-territorial-sanitaire/[numéroFiness].tsx
+++ b/src/pages/etablissement-territorial-sanitaire/[numéroFiness].tsx
@@ -8,6 +8,9 @@ import { ÉtablissementTerritorialSanitaireViewModel } from '../../frontend/ui/�
 export default function Router({ établissementTerritorial }:
   { établissementTerritorial: ÉtablissementTerritorialSanitaire }) {
   const { paths, wording } = useDependencies()
+
+  if (!établissementTerritorial) return null
+
   const établissementTerritorialViewModel = new ÉtablissementTerritorialSanitaireViewModel(établissementTerritorial, wording, paths)
   return <PageÉtablissementTerritorialSanitaire établissementTerritorialViewModel={établissementTerritorialViewModel} />
 }
@@ -27,6 +30,6 @@ export async function getStaticProps({ params }: { params: { numéroFiness: stri
     return { props: { établissementTerritorial }, revalidate: Number(environmentVariables.TIME_OF_CACHE_PAGE) }
   } catch (error) {
     dependencies.logger.error(error)
-    return { notFound: true }
+    return { notFound: true, revalidate: 1 }
   }
 }


### PR DESCRIPTION
- Rajout d'une condition dans `Router` pour éviter que le `build` ne casse
- Rajout de `revalidate: 1` pour dire que la page 404 ne dure qu'une seconde

Je vous invite à tester en local.
- suppression de .next
- suppression des volumes
- yarn dev pour lancer les migrations
- yarn build
- yarn start
- aller sur un ET ou EJ et voir que c'est en 404
- yarn populateDatabase:local
- aller sur l'ET/EJ précédent et voir que c'est en 200