### PR TITLE
(hel-275) Un ET mono-établissement est reconnu comme tel

### DIFF
--- a/src/backend/infrastructure/gateways/établissement-territorial-loader/TypeOrmÉtablissementTerritorialSanitaireLoader.test.ts
+++ b/src/backend/infrastructure/gateways/établissement-territorial-loader/TypeOrmÉtablissementTerritorialSanitaireLoader.test.ts
@@ -274,16 +274,16 @@ describe('Établissement territorial sanitaire loader', () => {
         ÉtablissementTerritorialAutorisationModelTestBuilder.créeAutorisationSanitaire({
           codeActivité: '16',
           codeForme: '14',
-          codeModalité: '42',
+          codeModalité: '45',
           libelléActivité: "Traitement de l'insuffisance rénale chronique par épuration extrarénale",
           libelléForme: 'Non saisonnier',
-          libelléModalité: 'Hémodialyse en unité médicalisée',
+          libelléModalité: 'Hémodialyse à domicile',
           numéroAutorisationArhgos: '01-00-0000',
           numéroFinessÉtablissementTerritorial,
         }),
         ÉtablissementTerritorialAutorisationModelTestBuilder.créeAutorisationSanitaire({
           codeActivité: '16',
-          codeForme: '00',
+          codeForme: '15',
           codeModalité: '42',
           libelléActivité: "Traitement de l'insuffisance rénale chronique par épuration extrarénale",
           libelléForme: 'Pas de forme',
@@ -303,7 +303,7 @@ describe('Établissement territorial sanitaire loader', () => {
         }),
         ÉtablissementTerritorialAutorisationModelTestBuilder.créeAutorisationSanitaire({
           codeActivité: '16',
-          codeForme: '14',
+          codeForme: '15',
           codeModalité: '45',
           libelléActivité: "Traitement de l'insuffisance rénale chronique par épuration extrarénale",
           libelléForme: 'Non saisonnier',
@@ -334,18 +334,8 @@ describe('Établissement territorial sanitaire loader', () => {
                       dateDeMiseEnOeuvre: '2008-12-04',
                       numéroArhgos: '02-00-0000',
                     },
-                    code: '00',
+                    code: '15',
                     libellé: 'Pas de forme',
-                  },
-                  {
-                    autorisationSanitaire: {
-                      dateDAutorisation: '2005-10-11',
-                      dateDeFin: '2026-05-03',
-                      dateDeMiseEnOeuvre: '2008-12-04',
-                      numéroArhgos: '01-00-0000',
-                    },
-                    code: '14',
-                    libellé: 'Non saisonnier',
                   },
                 ],
                 libellé: 'Hémodialyse en unité médicalisée',
@@ -358,9 +348,19 @@ describe('Établissement territorial sanitaire loader', () => {
                       dateDAutorisation: '2005-10-11',
                       dateDeFin: '2026-05-03',
                       dateDeMiseEnOeuvre: '2008-12-04',
-                      numéroArhgos: '04-00-0000',
+                      numéroArhgos: '01-00-0000',
                     },
                     code: '14',
+                    libellé: 'Non saisonnier',
+                  },
+                  {
+                    autorisationSanitaire: {
+                      dateDAutorisation: '2005-10-11',
+                      dateDeFin: '2026-05-03',
+                      dateDeMiseEnOeuvre: '2008-12-04',
+                      numéroArhgos: '04-00-0000',
+                    },
+                    code: '15',
                     libellé: 'Non saisonnier',
                   },
                 ],
@@ -426,8 +426,8 @@ describe('Établissement territorial sanitaire loader', () => {
       await autreActivitéSanitaireRepository.insert([
         ÉtablissementTerritorialAutorisationModelTestBuilder.créeAutreActivitéSanitaire({
           codeActivité: 'A1',
-          codeForme: '00',
-          codeModalité: 'M0',
+          codeForme: '15',
+          codeModalité: 'M1',
           libelléActivité: 'Dépôt de sang',
           libelléForme: 'Pas de forme',
           libelléModalité: "Dépôt d'urgence",
@@ -435,11 +435,11 @@ describe('Établissement territorial sanitaire loader', () => {
         }),
         ÉtablissementTerritorialAutorisationModelTestBuilder.créeAutreActivitéSanitaire({
           codeActivité: 'A1',
-          codeForme: '15',
-          codeModalité: 'M0',
+          codeForme: '14',
+          codeModalité: 'M2',
           libelléActivité: 'Dépôt de sang',
           libelléForme: 'Forme non précisée',
-          libelléModalité: "Dépôt d'urgence",
+          libelléModalité: 'Dépôt relais',
           numéroFinessÉtablissementTerritorial,
         }),
         ÉtablissementTerritorialAutorisationModelTestBuilder.créeAutreActivitéSanitaire({
@@ -495,17 +495,8 @@ describe('Établissement territorial sanitaire loader', () => {
             libellé: 'Dépôt de sang',
             modalités: [
               {
-                code: 'M0',
+                code: 'M1',
                 formes: [
-                  {
-                    autreActivitéSanitaire: {
-                      dateDAutorisation: '2019-06-03',
-                      dateDeFin: '2024-08-31',
-                      dateDeMiseEnOeuvre: '2019-06-03',
-                    },
-                    code: '00',
-                    libellé: 'Pas de forme',
-                  },
                   {
                     autreActivitéSanitaire: {
                       dateDAutorisation: '2019-06-03',
@@ -513,7 +504,7 @@ describe('Établissement territorial sanitaire loader', () => {
                       dateDeMiseEnOeuvre: '2019-06-03',
                     },
                     code: '15',
-                    libellé: 'Forme non précisée',
+                    libellé: 'Pas de forme',
                   },
                 ],
                 libellé: "Dépôt d'urgence",
@@ -521,6 +512,15 @@ describe('Établissement territorial sanitaire loader', () => {
               {
                 code: 'M2',
                 formes: [
+                  {
+                    autreActivitéSanitaire: {
+                      dateDAutorisation: '2019-06-03',
+                      dateDeFin: '2024-08-31',
+                      dateDeMiseEnOeuvre: '2019-06-03',
+                    },
+                    code: '14',
+                    libellé: 'Forme non précisée',
+                  },
                   {
                     autreActivitéSanitaire: {
                       dateDAutorisation: '2019-06-03',

--- a/src/backend/infrastructure/gateways/établissement-territorial-loader/TypeOrmÉtablissementTerritorialSanitaireLoader.ts
+++ b/src/backend/infrastructure/gateways/établissement-territorial-loader/TypeOrmÉtablissementTerritorialSanitaireLoader.ts
@@ -115,7 +115,6 @@ export class TypeOrmÉtablissementTerritorialSanitaireLoader implements Établis
     return await (await this.orm)
       .getRepository(AutreActivitéSanitaireModel)
       .find({
-        // TODO: si on range par ordre alpha alors les tests sont verts alors qu'ils ne devraient pas
         // eslint-disable-next-line sort-keys
         order: { codeActivité: 'ASC', codeModalité: 'ASC', codeForme: 'ASC' },
         where: { numéroFinessÉtablissementTerritorial },
@@ -126,7 +125,6 @@ export class TypeOrmÉtablissementTerritorialSanitaireLoader implements Établis
     return await (await this.orm)
       .getRepository(AutorisationSanitaireModel)
       .find({
-        // TODO: si on range par ordre alpha alors les tests sont verts alors qu'ils ne devraient pas
         // eslint-disable-next-line sort-keys
         order: { codeActivité: 'ASC', codeModalité: 'ASC', codeForme: 'ASC' },
         where: { numéroFinessÉtablissementTerritorial },

--- a/src/frontend/ui/établissement-territorial-médico-social/PageÉtablissementTerritorialMédicoSocialIdentité.test.tsx
+++ b/src/frontend/ui/établissement-territorial-médico-social/PageÉtablissementTerritorialMédicoSocialIdentité.test.tsx
@@ -111,7 +111,7 @@ describe('La page établissement territorial - bloc identité', () => {
     expect(statutÉtablissement).toBeInTheDocument()
   })
 
-  it('affiche l’indicateur de mono-établissement', () => {
+  it('affiche l’indicateur de mono-établissement à oui quand il est tout seul dans l’EJ', () => {
     // GIVEN
     const établissementTerritorialMonoÉtablissement =
       ÉtablissementTerritorialMédicoSocialViewModelTestBuilder.crée(wording, paths, {
@@ -130,6 +130,28 @@ describe('La page établissement territorial - bloc identité', () => {
     const labelMonoÉtablissement = within(indicateurs[7]).getByText(`${wording.MONO_ÉTABLISSEMENT} -`, { selector: 'p' })
     expect(labelMonoÉtablissement.textContent).toBe(`${wording.MONO_ÉTABLISSEMENT} - ${wording.MISE_À_JOUR} : 07/07/2021 - Source : FINESS`)
     const monoÉtablissement = within(indicateurs[7]).getByText(wording.OUI)
+    expect(monoÉtablissement).toBeInTheDocument()
+  })
+
+  it('affiche l’indicateur de mono-établissement à non quand il n’est pas tout seul dans l’EJ', () => {
+    // GIVEN
+    const établissementTerritorialMonoÉtablissement =
+      ÉtablissementTerritorialMédicoSocialViewModelTestBuilder.crée(wording, paths, {
+        estMonoÉtablissement: {
+          dateMiseÀJourSource: '2021-07-07',
+          value: false,
+        },
+      })
+
+    // WHEN
+    renderFakeComponent(<PageÉtablissementTerritorialMédicoSocial établissementTerritorialViewModel={établissementTerritorialMonoÉtablissement} />)
+
+    // THEN
+    const ficheDIdentité = screen.getByRole('region', { name: wording.TITRE_BLOC_IDENTITÉ })
+    const indicateurs = within(ficheDIdentité).getAllByRole('listitem')
+    const labelMonoÉtablissement = within(indicateurs[7]).getByText(`${wording.MONO_ÉTABLISSEMENT} -`, { selector: 'p' })
+    expect(labelMonoÉtablissement.textContent).toBe(`${wording.MONO_ÉTABLISSEMENT} - ${wording.MISE_À_JOUR} : 07/07/2021 - Source : FINESS`)
+    const monoÉtablissement = within(indicateurs[7]).getByText(wording.NON)
     expect(monoÉtablissement).toBeInTheDocument()
   })
 

--- a/src/frontend/ui/établissement-territorial-médico-social/ÉtablissementTerritorialMédicoSocialViewModel.tsx
+++ b/src/frontend/ui/établissement-territorial-médico-social/ÉtablissementTerritorialMédicoSocialViewModel.tsx
@@ -108,7 +108,7 @@ export class ÉtablissementTerritorialMédicoSocialViewModel extends GraphiqueVi
   }
 
   public get monoÉtablissement(): string {
-    return this.établissementTerritorial.identité.estMonoÉtablissement ? this.wording.OUI : this.wording.NON
+    return this.établissementTerritorial.identité.estMonoÉtablissement.value ? this.wording.OUI : this.wording.NON
   }
 
   public get dateDeMiseÀJourDuMonoÉtablissement(): string {


### PR DESCRIPTION
En bonus, j'ai corrigé des tests fragiles pour que si on enlève le `// eslint-disable-next-line sort-keys`, ils cassent.